### PR TITLE
Camera & Quick menu QoL improvements

### DIFF
--- a/unity/DigAndAnnotate/Assets/iwsd_vrc/Tools/OnEditorEmu/Scripts/PlayerCameraControl.cs
+++ b/unity/DigAndAnnotate/Assets/iwsd_vrc/Tools/OnEditorEmu/Scripts/PlayerCameraControl.cs
@@ -67,6 +67,7 @@ namespace Iwsd
 
             // move mouse cursor to center
             Cursor.lockState = CursorLockMode.Locked;
+            Cursor.visible = false;
             // Cursor.lockState = CursorLockMode.None;
         }
 
@@ -289,7 +290,7 @@ namespace Iwsd
             // incrementally add to the camera look
             mouseLook += smoothV;
             mouseLook.x = mouseLook.x % 360.0f;
-            mouseLook.y = mouseLook.y % 360.0f;
+            mouseLook.y = Mathf.Clamp(mouseLook.y, -90, 90);
             
             // mouse up-down => camera up-down
             // vector3.right means the x-axis
@@ -323,15 +324,22 @@ namespace Iwsd
         
         private void OperateToggleCursorLock()
         {
-            if (Input.GetKeyDown(KeyCode.Tab)) {
-                Cursor.lockState = (Cursor.lockState == CursorLockMode.Locked)? CursorLockMode.None: CursorLockMode.Locked;
+            if(Input.GetButtonUp("Cancel"))
+            {
+                Cursor.lockState = CursorLockMode.None;
+                Cursor.visible = true;
+            }
+            if (Input.GetMouseButtonUp(0))
+            {
+                Cursor.lockState = CursorLockMode.Locked;
+                Cursor.visible = false;
             }
         }
         
         void Update()
         {
             RayOperation();
-            RotateByMouseInput();
+            if(!Cursor.visible) RotateByMouseInput();
             OperateToggleCursorLock();
             UpdatePositionOfHoldings();
         }

--- a/unity/DigAndAnnotate/Assets/iwsd_vrc/Tools/OnEditorEmu/Scripts/PlayerControl.cs
+++ b/unity/DigAndAnnotate/Assets/iwsd_vrc/Tools/OnEditorEmu/Scripts/PlayerControl.cs
@@ -116,11 +116,7 @@ namespace Iwsd
         // (In UnitEditor ESC activates mouse cursor automatically. You can avoid this behavior by using alternative bind.)
         private void ToggleQuickMenuOperation()
         {
-            if (Input.GetButtonUp("Cancel")
-                #if UNITY_EDITOR
-                || Input.GetKeyDown(KeyCode.Q)
-                #endif
-                )
+            if (Input.GetKeyDown(KeyCode.Tab))
             {
                 Iwlog.Trace("Toggle QuickMenu");
                 if (QuickMenu.activeSelf)


### PR DESCRIPTION
This PR takes advantage of Unity's existing ESC key to get out of focus but gives the ability to go back into it if you click within the game window, furthermore the camera is clamped on the Y axis (90 degrees down, 90 degrees up) to prevent the camera from going upside down.

As the ESC key is used, the quick menu is now using the TAB key which seemed the most logical as Q can be used as a replacement for A in some keyboard layouts (i.e. French keyboards).