### PR TITLE
Unity 2018 and VRCSDK2 fix for iwsd_vrc Emu_Trigger.

### DIFF
--- a/unity/DigAndAnnotate/Assets/iwsd_vrc/Tools/OnEditorEmu/Scripts/Emu_Trigger.cs
+++ b/unity/DigAndAnnotate/Assets/iwsd_vrc/Tools/OnEditorEmu/Scripts/Emu_Trigger.cs
@@ -18,7 +18,13 @@ namespace Iwsd
 
         internal Val_Trigger(VRCSDK2.VRC_Trigger vrcTrigger)
         {
+#if UNITY_2018_4_OR_NEWER
+            // SDK2: The original VRC_Trigger is no longer destroyed, just disabled.
+            // So we can reference without a DeepCopy!
+            this.Triggers = vrcTrigger.Triggers;
+#else
             this.Triggers = DeepCopyHelper.DeepCopy<List<VRCSDK2.VRC_Trigger.TriggerEvent>>(vrcTrigger.Triggers); 
+#endif
         }
     }
     


### PR DESCRIPTION
Unity 2018 no longer supports serialization of components such as VRC_Trigger, used by DeepCopy.

However, as of VRCSDK2, the VRC_Trigger components are no longer destroyed, so a DeepCopy is no longer necessary. Therefore, we can safely reference the trigger list from the original component as a workaround.