### PR TITLE
Allow

### DIFF
--- a/unity/DigAndAnnotate/Assets/iwsd_vrc/Tools/OnEditorEmu/Scripts/Emu_Trigger.cs
+++ b/unity/DigAndAnnotate/Assets/iwsd_vrc/Tools/OnEditorEmu/Scripts/Emu_Trigger.cs
@@ -355,7 +355,7 @@ namespace Iwsd
         {
             if (vrcTrigger == null)
             {
-                Iwlog.Error(gameObject, "vrcTrigger == null");
+                Iwlog.Trace(gameObject, "vrcTrigger == null");
                 return Enumerable.Empty<VRCSDK2.VRC_Trigger.TriggerEvent>();
             }
             
@@ -741,7 +741,11 @@ namespace Iwsd
             {
                 comp.gameObject.GetOrAddComponent<Emu_Trigger>();
             }
-
+            // In-scene prefab references are spawned as inactive game objects.
+            // Usually the root object has an OnSpawn -> SetGameObjectActive true,
+            // but the Emu_Trigger cannot execute before the object is Awake().
+            // To workaround this, we force the newly spawned object active.
+            newOne.SetActive(true);
             foreach (var comp in newOne.GetComponentsInChildren<Emu_Trigger>(false))
             {
                 comp.ExecuteTriggers(VRCSDK2.VRC_Trigger.TriggerType.OnSpawn);

--- a/unity/DigAndAnnotate/Assets/iwsd_vrc/Tools/OnEditorEmu/Scripts/Emu_Trigger.cs
+++ b/unity/DigAndAnnotate/Assets/iwsd_vrc/Tools/OnEditorEmu/Scripts/Emu_Trigger.cs
@@ -23,7 +23,7 @@ namespace Iwsd
     }
     
     
-    class Emu_Trigger : MonoBehaviour
+    public class Emu_Trigger : MonoBehaviour
     {
         // [SerializeField] // TODO Make trigger definition visible with Unity inspector to debug scene.
         Val_Trigger vrcTrigger;
@@ -739,7 +739,7 @@ namespace Iwsd
             // true: includeInactive
             foreach (var comp in newOne.GetComponentsInChildren<VRCSDK2.VRC_Trigger>(true))
             {
-                comp.gameObject.AddComponent<Emu_Trigger>();
+                comp.gameObject.GetOrAddComponent<Emu_Trigger>();
             }
 
             foreach (var comp in newOne.GetComponentsInChildren<Emu_Trigger>(false))

--- a/unity/DigAndAnnotate/Assets/iwsd_vrc/Tools/OnEditorEmu/Scripts/InUnityDebug.cs
+++ b/unity/DigAndAnnotate/Assets/iwsd_vrc/Tools/OnEditorEmu/Scripts/InUnityDebug.cs
@@ -116,7 +116,7 @@ namespace Iwsd
                 }
 
                 // Emu_Trigger find brother VRC_Trigger by itself
-                var emu_trigger = triggerComp.gameObject.AddComponent<Emu_Trigger>();
+                var emu_trigger = triggerComp.gameObject.GetOrAddComponent<Emu_Trigger>();
 
                 emu_trigger.debugString = triggerComp.gameObject.name;
             }

--- a/unity/DigAndAnnotate/Assets/iwsd_vrc/Tools/OnEditorEmu/Scripts/LocalPlayerContext.cs
+++ b/unity/DigAndAnnotate/Assets/iwsd_vrc/Tools/OnEditorEmu/Scripts/LocalPlayerContext.cs
@@ -65,7 +65,11 @@ namespace Iwsd
 
             #if UNITY_EDITOR // This implementation requires UnityEditor.
             foreach (T obj in objects) {
-                var p =  UnityEditor.AssetDatabase.GetAssetPath(obj);
+                var p = UnityEditor.AssetDatabase.GetAssetPath(obj);
+                if (p == null || p.Length == 0) {
+                    // in-scene prefab references use the object name.
+                    p = obj.name;
+                }
                 Iwlog.Trace("asset path='" + p + "'");
                 if (map.ContainsKey(p)) {
                     Iwlog.Warn("Duplicate?: path='" + p + "'");


### PR DESCRIPTION
Permit Emu_Trigger components to be created prior to entering play mode. This is useful to add Emu_Trigger Interact or ExecuteCustomTrigger actions on UI Button for testing.

Allow SpawnObject to reference prefabs which are not assets; set spawned objects active to match VRC_Trigger behavior.